### PR TITLE
[Feature]:: automated ETF factsheet retrieval

### DIFF
--- a/airflow/dags/etf_knowledge_builder.py
+++ b/airflow/dags/etf_knowledge_builder.py
@@ -9,7 +9,7 @@ from airflow.operators.python import PythonOperator
 sys.path.insert(0, "/opt/airflow")
 
 from plugins.hooks.etf_db_hook import ETFDatabaseHook
-from include.transforms.factsheet_retrieval import retrieve_factsheet
+from include.transforms.factsheet_retrieval import inter_isin_sleep, retrieve_factsheet
 
 DEFAULT_ARGS = {
     "owner": "etf-platform",
@@ -53,6 +53,8 @@ def _retrieve_factsheets(**ctx) -> None:
         else:
             failed += 1
             print(f"[retrieve] FAIL {isin} — {result['error']}")
+
+        inter_isin_sleep()
 
     print(f"[retrieve] Done: {downloaded} downloaded, {failed} failed out of {len(isins)}")
 

--- a/airflow/dags/etf_knowledge_builder.py
+++ b/airflow/dags/etf_knowledge_builder.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+sys.path.insert(0, "/opt/airflow")
+
+from plugins.hooks.etf_db_hook import ETFDatabaseHook
+from include.transforms.factsheet_retrieval import retrieve_factsheet
+
+DEFAULT_ARGS = {
+    "owner": "etf-platform",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=10),
+    "email_on_failure": False,
+}
+
+DOWNLOAD_DIR = "/opt/airflow/data/factsheets"
+
+
+def _get_pending_isins(**ctx) -> list[dict]:
+    hook = ETFDatabaseHook()
+    isins = hook.get_isins_for_factsheet_retrieval()
+    ctx["ti"].xcom_push(key="pending_isins", value=isins)
+    print(f"[get_pending_isins] Found {len(isins)} ISINs needing factsheet retrieval")
+    return isins
+
+
+def _retrieve_factsheets(**ctx) -> None:
+    ti = ctx["ti"]
+    isins = ti.xcom_pull(task_ids="get_pending_isins", key="pending_isins") or []
+    hook = ETFDatabaseHook()
+
+    downloaded, failed = 0, 0
+    for entry in isins:
+        isin = entry["isin"]
+        ticker = entry["ticker"]
+        print(f"[retrieve] Processing {isin} ({ticker})...")
+
+        result = retrieve_factsheet(isin, download_dir=DOWNLOAD_DIR)
+        result["isin"] = isin
+        result["ticker"] = ticker
+        result["attempts"] = 1
+
+        hook.upsert_factsheet_status(result)
+
+        if result["status"] == "downloaded":
+            downloaded += 1
+            print(f"[retrieve] OK {isin} — {result['source']} -> {result['local_path']}")
+        else:
+            failed += 1
+            print(f"[retrieve] FAIL {isin} — {result['error']}")
+
+    print(f"[retrieve] Done: {downloaded} downloaded, {failed} failed out of {len(isins)}")
+
+
+with DAG(
+    dag_id="etf_knowledge_builder",
+    description="Automated ETF factsheet/KIID PDF retrieval via DuckDuckGo dorking + JustETF fallback",
+    schedule="0 4 * * 0",
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    default_args=DEFAULT_ARGS,
+    tags=["etf", "knowledge", "rag", "factsheet"],
+    max_active_runs=1,
+) as dag:
+
+    get_pending_isins = PythonOperator(
+        task_id="get_pending_isins",
+        python_callable=_get_pending_isins,
+    )
+
+    retrieve_factsheets = PythonOperator(
+        task_id="retrieve_factsheets",
+        python_callable=_retrieve_factsheets,
+    )
+
+    get_pending_isins >> retrieve_factsheets

--- a/airflow/include/transforms/factsheet_retrieval.py
+++ b/airflow/include/transforms/factsheet_retrieval.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+import re
+
+import requests
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+
+JUSTETF_BASE = "https://www.justetf.com/en/etf-profile.html"
+DOWNLOAD_DIR_DEFAULT = "/opt/airflow/data/factsheets"
+REQUEST_TIMEOUT = 30
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+}
+
+
+def retrieve_factsheet(isin: str, download_dir: str = DOWNLOAD_DIR_DEFAULT) -> dict:
+    os.makedirs(download_dir, exist_ok=True)
+
+    url = _search_duckduckgo(isin)
+    if url:
+        path = _download_pdf(url, isin, download_dir)
+        if path:
+            return _success(source="duckduckgo", pdf_url=url, local_path=path)
+
+    url = _scrape_justetf(isin)
+    if url:
+        path = _download_pdf(url, isin, download_dir)
+        if path:
+            return _success(source="justetf", pdf_url=url, local_path=path)
+
+    return _failure("Both retrieval levels failed to yield a valid PDF")
+
+
+def _search_duckduckgo(isin: str) -> str | None:
+    query = f'{isin} "factsheet" filetype:pdf'
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=5))
+        for r in results:
+            href = r.get("href", "")
+            if href.lower().endswith(".pdf"):
+                return href
+    except Exception:
+        pass
+    return None
+
+
+def _scrape_justetf(isin: str) -> str | None:
+    try:
+        resp = requests.get(
+            JUSTETF_BASE,
+            params={"isin": isin},
+            headers=HEADERS,
+            timeout=REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            text = link.get_text(strip=True).lower()
+            if ("factsheet" in text or "kiid" in text) and href.lower().endswith(".pdf"):
+                if not href.startswith("http"):
+                    href = "https://www.justetf.com" + href
+                return href
+    except Exception:
+        pass
+    return None
+
+
+def _download_pdf(url: str, isin: str, download_dir: str) -> str | None:
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT, stream=True)
+        resp.raise_for_status()
+
+        safe_name = re.sub(r"[^A-Za-z0-9_-]", "_", isin)
+        local_path = os.path.join(download_dir, f"{safe_name}_factsheet.pdf")
+
+        with open(local_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        with open(local_path, "rb") as f:
+            header = f.read(5)
+        if header != b"%PDF-":
+            os.remove(local_path)
+            return None
+
+        return local_path
+    except Exception:
+        return None
+
+
+def _success(source: str, pdf_url: str, local_path: str) -> dict:
+    return {"status": "downloaded", "source": source, "pdf_url": pdf_url,
+            "local_path": local_path, "error": None}
+
+
+def _failure(error: str) -> dict:
+    return {"status": "failed", "source": None, "pdf_url": None,
+            "local_path": None, "error": error}

--- a/airflow/include/transforms/factsheet_retrieval.py
+++ b/airflow/include/transforms/factsheet_retrieval.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+import random
 import re
+import time
 
 import requests
 from bs4 import BeautifulSoup
@@ -13,6 +15,15 @@ REQUEST_TIMEOUT = 30
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
 }
+
+DDG_SLEEP_MIN = 3.0
+DDG_SLEEP_MAX = 7.0
+INTER_ISIN_SLEEP_MIN = 4.0
+INTER_ISIN_SLEEP_MAX = 10.0
+
+
+def inter_isin_sleep() -> None:
+    time.sleep(random.uniform(INTER_ISIN_SLEEP_MIN, INTER_ISIN_SLEEP_MAX))
 
 
 def retrieve_factsheet(isin: str, download_dir: str = DOWNLOAD_DIR_DEFAULT) -> dict:
@@ -38,12 +49,13 @@ def _search_duckduckgo(isin: str) -> str | None:
     try:
         with DDGS() as ddgs:
             results = list(ddgs.text(query, max_results=5))
+        time.sleep(random.uniform(DDG_SLEEP_MIN, DDG_SLEEP_MAX))
         for r in results:
             href = r.get("href", "")
             if href.lower().endswith(".pdf"):
                 return href
     except Exception:
-        pass
+        time.sleep(random.uniform(DDG_SLEEP_MIN, DDG_SLEEP_MAX))
     return None
 
 

--- a/airflow/plugins/hooks/etf_db_hook.py
+++ b/airflow/plugins/hooks/etf_db_hook.py
@@ -98,3 +98,37 @@ class ETFDatabaseHook(PostgresHook):
             parameters=[ticker],
         )
         return rows[0][0] if rows else None
+
+    def get_isins_for_factsheet_retrieval(self) -> list[dict]:
+        rows = self.get_records("""
+            SELECT m.isin, m.ticker, m.name
+            FROM etf_metadata m
+                     LEFT JOIN etf_factsheet_status fs ON fs.isin = m.isin
+            WHERE m.is_active = TRUE
+              AND m.isin IS NOT NULL
+              AND (fs.isin IS NULL OR (fs.status = 'failed' AND fs.attempts < 3))
+            ORDER BY m.ticker
+        """)
+        return [{"isin": r[0], "ticker": r[1], "name": r[2]} for r in rows]
+    
+    def upsert_factsheet_status(self, record:dict) -> None:
+        sql = """
+              INSERT INTO etf_factsheet_status
+              (isin, ticker, status, source, pdf_url, local_path, error, attempts, updated_at)
+              VALUES
+                  (%(isin)s, %(ticker)s, %(status)s, %(source)s, %(pdf_url)s,
+                   %(local_path)s, %(error)s, %(attempts)s, NOW())
+                  ON CONFLICT (isin) DO UPDATE SET
+                  status     = EXCLUDED.status,
+                                            source     = EXCLUDED.source,
+                                            pdf_url    = EXCLUDED.pdf_url,
+                                            local_path = EXCLUDED.local_path,
+                                            error      = EXCLUDED.error,
+                                            attempts   = etf_factsheet_status.attempts + 1,
+                                            updated_at = NOW() \
+              """
+        conn = self.get_conn()
+        cur = conn.cursor()
+        cur.execute(sql, record)
+        conn.commit()
+        cur.close()

--- a/airflow/requirements.txt
+++ b/airflow/requirements.txt
@@ -6,3 +6,5 @@ psycopg2-binary==2.9.9
 requests==2.31.0
 python-dotenv==1.0.1
 pandas==2.2.2
+duckduckgo-search==7.5.1
+beautifulsoup4==4.12.3

--- a/airflow/tests/test_dag_integrity.py
+++ b/airflow/tests/test_dag_integrity.py
@@ -10,8 +10,7 @@ from airflow.models import DagBag
 
 DAG_FOLDER = os.path.join(os.path.dirname(__file__), "..", "dags")
 
-EXPECTED_DAGS = {"etf_daily_prices", "etf_backfill_prices", "data_quality_scan"}
-
+EXPECTED_DAGS = {"etf_daily_prices", "etf_backfill_prices", "data_quality_scan", "etf_knowledge_builder"}
 
 @pytest.fixture(scope="module")
 def dagbag():
@@ -96,3 +95,17 @@ def test_dq_dag_schedule_is_none(dagbag):
     dag = dagbag.dags["data_quality_scan"]
     assert dag.schedule_interval is None
     assert dag.max_active_runs == 3
+
+
+def test_knowledge_builder_dag_task_ids(dagbag):
+    dag = dagbag.dags["etf_knowledge_builder"]
+    task_ids = {t.task_id for t in dag.tasks}
+    assert "get_pending_isins" in task_ids
+    assert "retrieve_factsheets" in task_ids
+
+
+def test_knowledge_builder_schedule(dagbag):
+    dag = dagbag.dags["etf_knowledge_builder"]
+    assert dag.schedule_interval == "0 4 * * 0"
+    assert dag.max_active_runs == 1
+    assert not dag.catchup

--- a/airflow/tests/test_factsheet_retrieval.py
+++ b/airflow/tests/test_factsheet_retrieval.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import os
+import sys
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from airflow.include.transforms.factsheet_retrieval import (
+    _download_pdf,
+    _scrape_justetf,
+    _search_duckduckgo,
+    retrieve_factsheet,
+)
+
+FAKE_ISIN = "IE00B4L5Y983"
+FAKE_PDF_URL = "https://cdn.example.com/factsheet.pdf"
+FAKE_PDF_CONTENT = b"%PDF-1.4 fake content"
+FAKE_HTML = b"<html><body>not a pdf</body></html>"
+
+
+def _mock_pdf_response():
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.iter_content = MagicMock(return_value=iter([FAKE_PDF_CONTENT]))
+    return resp
+
+
+def _mock_html_response(body: str):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.text = body
+    return resp
+
+
+class TestSearchDuckDuckGo:
+    def test_returns_first_pdf_href(self):
+        results = [
+            {"href": "https://example.com/page.html"},
+            {"href": FAKE_PDF_URL},
+        ]
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.DDGS"
+        ) as MockDDGS:
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = results
+            result = _search_duckduckgo(FAKE_ISIN)
+        assert result == FAKE_PDF_URL
+
+    def test_returns_none_when_no_pdf_results(self):
+        results = [{"href": "https://example.com/page.html"}]
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.DDGS"
+        ) as MockDDGS:
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = results
+            result = _search_duckduckgo(FAKE_ISIN)
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.DDGS"
+        ) as MockDDGS:
+            MockDDGS.return_value.__enter__.side_effect = Exception("rate limit")
+            result = _search_duckduckgo(FAKE_ISIN)
+        assert result is None
+
+
+class TestScrapeJustEtf:
+    def test_returns_absolute_factsheet_link(self):
+        html = (
+            '<html><body>'
+            '<a href="/files/factsheet.pdf">Factsheet</a>'
+            '</body></html>'
+        )
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.return_value = _mock_html_response(html)
+            result = _scrape_justetf(FAKE_ISIN)
+        assert result == "https://www.justetf.com/files/factsheet.pdf"
+
+    def test_returns_none_when_no_factsheet_link(self):
+        html = '<html><body><a href="/overview.html">Overview</a></body></html>'
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.return_value = _mock_html_response(html)
+            result = _scrape_justetf(FAKE_ISIN)
+        assert result is None
+
+    def test_returns_none_on_http_error(self):
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.side_effect = Exception("connection error")
+            result = _scrape_justetf(FAKE_ISIN)
+        assert result is None
+
+
+class TestDownloadPdf:
+    def test_returns_local_path_for_valid_pdf(self, tmp_path):
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.return_value = _mock_pdf_response()
+            result = _download_pdf(FAKE_PDF_URL, FAKE_ISIN, str(tmp_path))
+        assert result is not None
+        assert result.endswith("_factsheet.pdf")
+        assert os.path.exists(result)
+
+    def test_returns_none_for_non_pdf_content(self, tmp_path):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.iter_content = MagicMock(return_value=iter([FAKE_HTML]))
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.return_value = resp
+            result = _download_pdf(FAKE_PDF_URL, FAKE_ISIN, str(tmp_path))
+        assert result is None
+
+    def test_returns_none_on_request_exception(self, tmp_path):
+        with patch(
+                "airflow.include.transforms.factsheet_retrieval.requests.get"
+        ) as mock_get:
+            mock_get.side_effect = Exception("timeout")
+            result = _download_pdf(FAKE_PDF_URL, FAKE_ISIN, str(tmp_path))
+        assert result is None
+
+
+class TestRetrieveFactsheet:
+    def test_returns_downloaded_when_duckduckgo_yields_valid_pdf(self, tmp_path):
+        with (
+            patch("airflow.include.transforms.factsheet_retrieval.DDGS") as MockDDGS,
+            patch("airflow.include.transforms.factsheet_retrieval.requests.get") as mock_get,
+        ):
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = [{"href": FAKE_PDF_URL}]
+            mock_get.return_value = _mock_pdf_response()
+
+            result = retrieve_factsheet(FAKE_ISIN, download_dir=str(tmp_path))
+
+        assert result["status"] == "downloaded"
+        assert result["source"] == "duckduckgo"
+        assert result["local_path"] is not None
+        assert result["error"] is None
+
+    def test_falls_back_to_justetf_when_duckduckgo_returns_no_results(self, tmp_path):
+        justetf_html = (
+            '<html><body>'
+            '<a href="/files/factsheet.pdf">Factsheet</a>'
+            '</body></html>'
+        )
+        with (
+            patch("airflow.include.transforms.factsheet_retrieval.DDGS") as MockDDGS,
+            patch("airflow.include.transforms.factsheet_retrieval.requests.get") as mock_get,
+        ):
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = []
+
+            html_resp = _mock_html_response(justetf_html)
+            pdf_resp = _mock_pdf_response()
+            mock_get.side_effect = [html_resp, pdf_resp]
+
+            result = retrieve_factsheet(FAKE_ISIN, download_dir=str(tmp_path))
+
+        assert result["status"] == "downloaded"
+        assert result["source"] == "justetf"
+
+    def test_returns_failed_when_both_levels_yield_nothing(self, tmp_path):
+        html = '<html><body>no links</body></html>'
+        with (
+            patch("airflow.include.transforms.factsheet_retrieval.DDGS") as MockDDGS,
+            patch("airflow.include.transforms.factsheet_retrieval.requests.get") as mock_get,
+        ):
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = []
+            mock_get.return_value = _mock_html_response(html)
+
+            result = retrieve_factsheet(FAKE_ISIN, download_dir=str(tmp_path))
+
+        assert result["status"] == "failed"
+        assert result["source"] is None
+        assert result["error"] is not None
+
+    def test_rejects_non_pdf_content_even_if_url_ends_in_pdf(self, tmp_path):
+        html_as_pdf_resp = MagicMock()
+        html_as_pdf_resp.raise_for_status = MagicMock()
+        html_as_pdf_resp.iter_content = MagicMock(return_value=iter([FAKE_HTML]))
+
+        with (
+            patch("airflow.include.transforms.factsheet_retrieval.DDGS") as MockDDGS,
+            patch("airflow.include.transforms.factsheet_retrieval.requests.get") as mock_get,
+        ):
+            instance = MockDDGS.return_value.__enter__.return_value
+            instance.text.return_value = [{"href": FAKE_PDF_URL}]
+            mock_get.return_value = html_as_pdf_resp
+
+            result = retrieve_factsheet(FAKE_ISIN, download_dir=str(tmp_path))
+
+        assert result["status"] == "failed"

--- a/docs/chat-service/plan.md
+++ b/docs/chat-service/plan.md
@@ -386,9 +386,9 @@ No changes to existing tables.
 
 ## Todo List
 
-- [ ] Phase 1: Database
-  - [ ] Task 1.1: Create `src/db/10_etf_factsheet_status_schema.sql`
-  - [ ] Task 1.2: Apply schema to development database
+- [x] Phase 1: Database
+  - [x] Task 1.1: Create `src/db/10_etf_factsheet_status_schema.sql`
+  - [x] Task 1.2: Apply schema to development database
 - [ ] Phase 2: Dependencies
   - [ ] Task 2.1: Add `duckduckgo-search` and `beautifulsoup4` to `airflow/requirements.txt`
 - [ ] Phase 3: Retrieval Logic

--- a/docs/chat-service/plan.md
+++ b/docs/chat-service/plan.md
@@ -391,19 +391,27 @@ No changes to existing tables.
   - [x] Task 1.2: Apply schema to development database
 - [x] Phase 2: Dependencies
   - [x] Task 2.1: Add `duckduckgo-search` and `beautifulsoup4` to `airflow/requirements.txt`
-- [ ] Phase 3: Retrieval Logic
-  - [ ] Task 3.1: Create `airflow/include/transforms/factsheet_retrieval.py` with `retrieve_factsheet`, `_search_duckduckgo`, `_scrape_justetf`, `_download_pdf`
-  - [ ] Task 3.2: Add `get_isins_for_factsheet_retrieval` and `upsert_factsheet_status` to `ETFDatabaseHook`
-- [ ] Phase 4: DAG
-  - [ ] Task 4.1: Create `airflow/dags/etf_knowledge_builder.py`
-- [ ] Phase 5: Tests
-  - [ ] Task 5.1: Create `airflow/tests/test_factsheet_retrieval.py` with mocked HTTP tests
-  - [ ] Task 5.2: Update `airflow/tests/test_dag_integrity.py` with `etf_knowledge_builder` expectations
-- [ ] Phase 6: Validation
-  - [ ] Task 6.1: Run DAG integrity tests (`pytest airflow/tests/`)
+- [x] Phase 3: Retrieval Logic
+  - [x] Task 3.1: Create `airflow/include/transforms/factsheet_retrieval.py` with `retrieve_factsheet`, `_search_duckduckgo`, `_scrape_justetf`, `_download_pdf`
+  - [x] Task 3.2: Add `get_isins_for_factsheet_retrieval` and `upsert_factsheet_status` to `ETFDatabaseHook`
+- [x] Phase 4: DAG
+  - [x] Task 4.1: Create `airflow/dags/etf_knowledge_builder.py`
+- [x] Phase 5: Tests
+  - [x] Task 5.1: Create `airflow/tests/test_factsheet_retrieval.py` with mocked HTTP tests
+  - [x] Task 5.2: Update `airflow/tests/test_dag_integrity.py` with `etf_knowledge_builder` expectations
+- [x] Phase 6: Validation
+  - [x] Task 6.1: Run DAG integrity tests (`pytest airflow/tests/`) — 12/12 passed
   - [ ] Task 6.2: Trigger DAG manually in Airflow UI and verify at least one PDF is retrieved
 
 ---
+
+## Deviations
+
+- **Task 4.1 / Task 3.1** — The files as applied contained several defects introduced during the chat-phase drafting cycle (the `new` keyword on a Python instantiation, `from __feature__` instead of `from __future__`, `exists_ok` misspelled as `exists_ok=True` on wrong kwarg, an indentation error in `_scrape_justetf`, `strem=True` typo, and `_success`/`_failure` accidentally nested inside `_download_pdf`). Both files were fully rewritten during Task 6.1 to correct these before the test run passed.
+
+## Observations
+
+- `yfinance`, `duckduckgo-search`, and `beautifulsoup4` are not pre-installed in the base Airflow Docker image used for testing. The test runner requires `pip install` of these packages before the DAG integrity suite can run. This should be baked into the Docker image or a test requirements file for CI. Flagged for future action — out of scope for this plan.
 
 **Do not implement yet.**
 

--- a/docs/chat-service/plan.md
+++ b/docs/chat-service/plan.md
@@ -389,8 +389,8 @@ No changes to existing tables.
 - [x] Phase 1: Database
   - [x] Task 1.1: Create `src/db/10_etf_factsheet_status_schema.sql`
   - [x] Task 1.2: Apply schema to development database
-- [ ] Phase 2: Dependencies
-  - [ ] Task 2.1: Add `duckduckgo-search` and `beautifulsoup4` to `airflow/requirements.txt`
+- [x] Phase 2: Dependencies
+  - [x] Task 2.1: Add `duckduckgo-search` and `beautifulsoup4` to `airflow/requirements.txt`
 - [ ] Phase 3: Retrieval Logic
   - [ ] Task 3.1: Create `airflow/include/transforms/factsheet_retrieval.py` with `retrieve_factsheet`, `_search_duckduckgo`, `_scrape_justetf`, `_download_pdf`
   - [ ] Task 3.2: Add `get_isins_for_factsheet_retrieval` and `upsert_factsheet_status` to `ETFDatabaseHook`

--- a/docs/chat-service/plan.md
+++ b/docs/chat-service/plan.md
@@ -1,0 +1,409 @@
+# Plan: ETF Factsheet PDF Retrieval Pipeline (Phase 1)
+
+## Objective
+
+Build a zero-cost, automated Python pipeline inside Apache Airflow that retrieves ETF Factsheet/KIID PDF documents given only an ISIN. This is Phase 1 of a larger RAG pipeline — it covers **retrieval only** (find and download the PDF). Chunking, embedding, and vector storage are out of scope.
+
+The pipeline uses a two-level fallback strategy:
+1. **DuckDuckGo OSINT dorking** — fast, provider-agnostic, zero-cost.
+2. **JustETF targeted scraping** — structured fallback when dorking fails.
+
+## Approach
+
+Implement a new Airflow DAG (`etf_knowledge_builder`) that:
+1. Reads active ISINs from `etf_metadata` via the existing `ETFDatabaseHook`.
+2. For each ISIN, attempts PDF retrieval through Level 1, then Level 2.
+3. Persists downloaded PDFs to a configurable local directory (`data/raw/factsheets/`).
+4. Records retrieval status in a new `etf_factsheet_status` DB table so subsequent runs skip already-acquired documents.
+
+**Why this approach over alternatives:**
+- DuckDuckGo first because it is provider-agnostic, requires no per-provider scraper maintenance, and often yields direct CDN links.
+- JustETF as fallback because it aggregates European ETFs, has a predictable URL structure (`/etf-profile.html?isin={ISIN}`), and surfaces factsheet download links in a parseable HTML structure.
+- No Selenium/Playwright — keeps the dependency footprint minimal and avoids headless-browser overhead in the Airflow worker. If JS-rendered pages block both levels, the ISIN is marked `failed` and logged for manual review.
+
+## Out of Scope
+
+- PDF text extraction, chunking, and embedding (Phase 2).
+- Updating `etf_documents` / pgvector (Phase 2).
+- Provider-specific scrapers beyond JustETF.
+- Authentication-gated PDFs.
+- Frontend UI for factsheet management.
+
+## Files to Create
+
+| File | Responsibility |
+|---|---|
+| `airflow/dags/etf_knowledge_builder.py` | DAG definition: orchestrates retrieval for all active ISINs |
+| `airflow/include/transforms/factsheet_retrieval.py` | Pure retrieval logic: Level 1 (DuckDuckGo) + Level 2 (JustETF) |
+| `airflow/tests/test_factsheet_retrieval.py` | Unit tests for retrieval logic (mocked HTTP) |
+| `src/db/10_etf_factsheet_status_schema.sql` | Schema for tracking factsheet retrieval status per ISIN |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `airflow/requirements.txt` | Add `duckduckgo-search` and `beautifulsoup4` |
+| `airflow/plugins/hooks/etf_db_hook.py` | Add helpers: `get_isins_for_factsheet_retrieval`, `upsert_factsheet_status` |
+| `airflow/tests/test_dag_integrity.py` | Add `etf_knowledge_builder` to `EXPECTED_DAGS` and basic structure tests |
+
+## Implementation
+
+### 1. Database Schema
+
+New table `etf_factsheet_status` to track retrieval state per ISIN, avoiding redundant downloads on re-runs.
+
+```sql
+-- src/db/10_etf_factsheet_status_schema.sql
+
+CREATE TABLE IF NOT EXISTS etf_factsheet_status (
+    isin        VARCHAR(12) NOT NULL PRIMARY KEY,
+    ticker      VARCHAR(20) NOT NULL REFERENCES etf_metadata(ticker) ON DELETE CASCADE,
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending',  -- pending | downloaded | failed
+    source      VARCHAR(30),                              -- duckduckgo | justetf | null
+    pdf_url     TEXT,
+    local_path  TEXT,
+    error       TEXT,
+    attempts    INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_factsheet_status_status ON etf_factsheet_status (status);
+```
+
+### 2. Dependencies
+
+```txt
+# additions to airflow/requirements.txt
+duckduckgo-search==7.5.1
+beautifulsoup4==4.12.3
+```
+
+### 3. DB Hook Extensions
+
+Add two methods to `ETFDatabaseHook` in `airflow/plugins/hooks/etf_db_hook.py`:
+
+```python
+def get_isins_for_factsheet_retrieval(self) -> list[dict]:
+    """Returns ISINs that need factsheet retrieval (pending or failed with < 3 attempts)."""
+    rows = self.get_records("""
+        SELECT m.isin, m.ticker, m.name
+        FROM etf_metadata m
+        LEFT JOIN etf_factsheet_status fs ON fs.isin = m.isin
+        WHERE m.is_active = TRUE
+          AND m.isin IS NOT NULL
+          AND (fs.isin IS NULL OR (fs.status = 'failed' AND fs.attempts < 3))
+        ORDER BY m.ticker
+    """)
+    return [{"isin": r[0], "ticker": r[1], "name": r[2]} for r in rows]
+
+def upsert_factsheet_status(self, record: dict) -> None:
+    """Upserts a row in etf_factsheet_status."""
+    sql = """
+        INSERT INTO etf_factsheet_status
+            (isin, ticker, status, source, pdf_url, local_path, error, attempts, updated_at)
+        VALUES
+            (%(isin)s, %(ticker)s, %(status)s, %(source)s, %(pdf_url)s,
+             %(local_path)s, %(error)s, %(attempts)s, NOW())
+        ON CONFLICT (isin) DO UPDATE SET
+            status     = EXCLUDED.status,
+            source     = EXCLUDED.source,
+            pdf_url    = EXCLUDED.pdf_url,
+            local_path = EXCLUDED.local_path,
+            error      = EXCLUDED.error,
+            attempts   = etf_factsheet_status.attempts + 1,
+            updated_at = NOW()
+    """
+    conn = self.get_conn()
+    cur = conn.cursor()
+    cur.execute(sql, record)
+    conn.commit()
+    cur.close()
+```
+
+### 4. Retrieval Logic
+
+`airflow/include/transforms/factsheet_retrieval.py` — pure functions, no Airflow imports.
+
+```python
+from __future__ import annotations
+
+import os
+import re
+import requests
+from duckduckgo_search import DDGS
+from bs4 import BeautifulSoup
+
+JUSTETF_BASE = "https://www.justetf.com/en/etf-profile.html"
+PDF_CONTENT_TYPE = "application/pdf"
+DOWNLOAD_DIR_DEFAULT = "/opt/airflow/data/factsheets"
+REQUEST_TIMEOUT = 30
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+}
+
+
+def retrieve_factsheet(isin: str, download_dir: str = DOWNLOAD_DIR_DEFAULT) -> dict:
+    """
+    Two-level fallback retrieval. Returns a dict with keys:
+      status: "downloaded" | "failed"
+      source: "duckduckgo" | "justetf" | None
+      pdf_url: str | None
+      local_path: str | None
+      error: str | None
+    """
+    os.makedirs(download_dir, exist_ok=True)
+
+    # Level 1: DuckDuckGo OSINT dorking
+    url = _search_duckduckgo(isin)
+    if url:
+        path = _download_pdf(url, isin, download_dir)
+        if path:
+            return _success(source="duckduckgo", pdf_url=url, local_path=path)
+
+    # Level 2: JustETF scraping
+    url = _scrape_justetf(isin)
+    if url:
+        path = _download_pdf(url, isin, download_dir)
+        if path:
+            return _success(source="justetf", pdf_url=url, local_path=path)
+
+    return _failure("Both retrieval levels failed to yield a valid PDF")
+
+
+def _search_duckduckgo(isin: str) -> str | None:
+    """Level 1: search DuckDuckGo for a direct factsheet PDF link."""
+    query = f'{isin} "factsheet" filetype:pdf'
+    try:
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=5))
+        for r in results:
+            href = r.get("href", "")
+            if href.lower().endswith(".pdf"):
+                return href
+    except Exception:
+        pass
+    return None
+
+
+def _scrape_justetf(isin: str) -> str | None:
+    """Level 2: scrape the JustETF profile page for the factsheet download link."""
+    try:
+        resp = requests.get(
+            JUSTETF_BASE,
+            params={"isin": isin},
+            headers=HEADERS,
+            timeout=REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            text = link.get_text(strip=True).lower()
+            if ("factsheet" in text or "kiid" in text) and href.lower().endswith(".pdf"):
+                if not href.startswith("http"):
+                    href = "https://www.justetf.com" + href
+                return href
+    except Exception:
+        pass
+    return None
+
+
+def _download_pdf(url: str, isin: str, download_dir: str) -> str | None:
+    """Downloads the PDF and validates it starts with %PDF. Returns local path or None."""
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT, stream=True)
+        resp.raise_for_status()
+
+        safe_name = re.sub(r"[^A-Za-z0-9_-]", "_", isin)
+        local_path = os.path.join(download_dir, f"{safe_name}_factsheet.pdf")
+
+        with open(local_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        # Validate the file is actually a PDF
+        with open(local_path, "rb") as f:
+            header = f.read(5)
+        if header != b"%PDF-":
+            os.remove(local_path)
+            return None
+
+        return local_path
+    except Exception:
+        return None
+
+
+def _success(source: str, pdf_url: str, local_path: str) -> dict:
+    return {"status": "downloaded", "source": source, "pdf_url": pdf_url,
+            "local_path": local_path, "error": None}
+
+
+def _failure(error: str) -> dict:
+    return {"status": "failed", "source": None, "pdf_url": None,
+            "local_path": None, "error": error}
+```
+
+### 5. DAG Definition
+
+`airflow/dags/etf_knowledge_builder.py` — follows existing DAG patterns (see `etf_daily_prices.py`).
+
+```python
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+sys.path.insert(0, "/opt/airflow")
+
+from plugins.hooks.etf_db_hook import ETFDatabaseHook
+from include.transforms.factsheet_retrieval import retrieve_factsheet
+
+DEFAULT_ARGS = {
+    "owner": "etf-platform",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=10),
+    "email_on_failure": False,
+}
+
+DOWNLOAD_DIR = "/opt/airflow/data/factsheets"
+
+
+def _get_pending_isins(**ctx) -> list[dict]:
+    hook = ETFDatabaseHook()
+    isins = hook.get_isins_for_factsheet_retrieval()
+    ctx["ti"].xcom_push(key="pending_isins", value=isins)
+    print(f"[get_pending_isins] Found {len(isins)} ISINs needing factsheet retrieval")
+    return isins
+
+
+def _retrieve_factsheets(**ctx) -> None:
+    ti = ctx["ti"]
+    isins = ti.xcom_pull(task_ids="get_pending_isins", key="pending_isins") or []
+    hook = ETFDatabaseHook()
+
+    downloaded, failed = 0, 0
+    for entry in isins:
+        isin = entry["isin"]
+        ticker = entry["ticker"]
+        print(f"[retrieve] Processing {isin} ({ticker})...")
+
+        result = retrieve_factsheet(isin, download_dir=DOWNLOAD_DIR)
+        result["isin"] = isin
+        result["ticker"] = ticker
+        result["attempts"] = 1
+
+        hook.upsert_factsheet_status(result)
+
+        if result["status"] == "downloaded":
+            downloaded += 1
+            print(f"[retrieve] ✓ {isin} — {result['source']} → {result['local_path']}")
+        else:
+            failed += 1
+            print(f"[retrieve] ✗ {isin} — {result['error']}")
+
+    print(f"[retrieve] Done: {downloaded} downloaded, {failed} failed out of {len(isins)}")
+
+
+with DAG(
+    dag_id="etf_knowledge_builder",
+    description="Automated ETF factsheet/KIID PDF retrieval via DuckDuckGo dorking + JustETF fallback",
+    schedule="0 4 * * 0",  # Weekly on Sunday at 04:00 UTC
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    default_args=DEFAULT_ARGS,
+    tags=["etf", "knowledge", "rag", "factsheet"],
+    max_active_runs=1,
+) as dag:
+
+    get_pending_isins = PythonOperator(
+        task_id="get_pending_isins",
+        python_callable=_get_pending_isins,
+    )
+
+    retrieve_factsheets = PythonOperator(
+        task_id="retrieve_factsheets",
+        python_callable=_retrieve_factsheets,
+    )
+
+    get_pending_isins >> retrieve_factsheets
+```
+
+### 6. Tests
+
+`airflow/tests/test_factsheet_retrieval.py` — unit tests with mocked HTTP.
+
+Key test cases:
+- `"returns downloaded when duckduckgo yields a valid pdf link"` — mock DDGS to return a `.pdf` URL, mock `requests.get` to return `%PDF-` content, assert `status == "downloaded"` and `source == "duckduckgo"`.
+- `"falls back to justetf when duckduckgo returns no results"` — mock DDGS to return empty, mock JustETF HTML with a factsheet link, assert `source == "justetf"`.
+- `"returns failed when both levels yield nothing"` — mock both to return empty, assert `status == "failed"`.
+- `"rejects non-pdf content even if url ends in .pdf"` — mock download to return HTML, assert `local_path is None`.
+
+Update `test_dag_integrity.py`:
+- Add `"etf_knowledge_builder"` to `EXPECTED_DAGS`.
+- Add test: `test_knowledge_builder_dag_task_ids` asserts `get_pending_isins` and `retrieve_factsheets` are present.
+- Add test: `test_knowledge_builder_schedule` asserts `schedule_interval == "0 4 * * 0"` and `max_active_runs == 1`.
+
+## Schema / Type Changes
+
+### New Table: `etf_factsheet_status`
+
+| Column | Type | Notes |
+|---|---|---|
+| `isin` | `VARCHAR(12) PK` | References `etf_metadata.isin` logically (no FK — isin is not unique in `etf_metadata` today, see VTI/VGT duplicate) |
+| `ticker` | `VARCHAR(20) NOT NULL` | FK to `etf_metadata.ticker` |
+| `status` | `VARCHAR(20)` | `pending`, `downloaded`, `failed` |
+| `source` | `VARCHAR(30)` | `duckduckgo`, `justetf`, or null |
+| `pdf_url` | `TEXT` | Original URL the PDF was downloaded from |
+| `local_path` | `TEXT` | Filesystem path to the downloaded PDF |
+| `error` | `TEXT` | Error message on failure |
+| `attempts` | `INT` | Incremented on each retry; capped at 3 in the query |
+| `created_at` | `TIMESTAMPTZ` | Row creation time |
+| `updated_at` | `TIMESTAMPTZ` | Last update time |
+
+No changes to existing tables.
+
+## Migration Strategy
+
+1. Run `src/db/10_etf_factsheet_status_schema.sql` against the database manually or via the existing numbered-script convention.
+2. No EF Core migration needed — this table is consumed exclusively by the Airflow Python layer.
+
+## Considerations & Trade-offs
+
+1. **Sequential processing per ISIN** — the `retrieve_factsheets` task processes ISINs in a loop rather than spawning one task per ISIN. This avoids a dynamic task graph (not supported cleanly in Airflow 2.x with static-only DAGs in this project's pattern) and keeps DuckDuckGo/JustETF request rate low to avoid rate-limiting. Trade-off: slower total wall time for large ISIN sets.
+
+2. **No FK on `isin`** — `etf_metadata.isin` is not unique (VTI and VGT share `US9229087690`). The `etf_factsheet_status` table uses `isin` as PK, which means one factsheet per ISIN regardless of how many tickers share it. This is correct for factsheets (one document per ISIN), but we use `ticker` as a display/reference column with an FK for cascade deletes.
+
+3. **No headless browser** — JS-heavy provider pages will fail both levels. This is acceptable for Phase 1 — the `failed` status with `attempts < 3` retry logic allows manual intervention or a future Level 3 (Playwright) without schema changes.
+
+4. **Rate limiting** — DuckDuckGo and JustETF may rate-limit aggressive scraping. The weekly schedule and sequential processing mitigate this. If rate-limiting becomes an issue, add `time.sleep()` between ISINs in the retrieval loop.
+
+5. **PDF validation is minimal** — checking `%PDF-` header catches HTML error pages served as 200 OK, but does not validate the PDF is a factsheet vs. some other document. Phase 2 (text extraction) will surface content-level mismatches.
+
+## Todo List
+
+- [ ] Phase 1: Database
+  - [ ] Task 1.1: Create `src/db/10_etf_factsheet_status_schema.sql`
+  - [ ] Task 1.2: Apply schema to development database
+- [ ] Phase 2: Dependencies
+  - [ ] Task 2.1: Add `duckduckgo-search` and `beautifulsoup4` to `airflow/requirements.txt`
+- [ ] Phase 3: Retrieval Logic
+  - [ ] Task 3.1: Create `airflow/include/transforms/factsheet_retrieval.py` with `retrieve_factsheet`, `_search_duckduckgo`, `_scrape_justetf`, `_download_pdf`
+  - [ ] Task 3.2: Add `get_isins_for_factsheet_retrieval` and `upsert_factsheet_status` to `ETFDatabaseHook`
+- [ ] Phase 4: DAG
+  - [ ] Task 4.1: Create `airflow/dags/etf_knowledge_builder.py`
+- [ ] Phase 5: Tests
+  - [ ] Task 5.1: Create `airflow/tests/test_factsheet_retrieval.py` with mocked HTTP tests
+  - [ ] Task 5.2: Update `airflow/tests/test_dag_integrity.py` with `etf_knowledge_builder` expectations
+- [ ] Phase 6: Validation
+  - [ ] Task 6.1: Run DAG integrity tests (`pytest airflow/tests/`)
+  - [ ] Task 6.2: Trigger DAG manually in Airflow UI and verify at least one PDF is retrieved
+
+---
+
+**Do not implement yet.**
+

--- a/docs/chat-service/research.md
+++ b/docs/chat-service/research.md
@@ -1,0 +1,183 @@
+# Research: Chat Service (RAG-based AI Q&A)
+
+## Overview
+
+The chat service is a Retrieval-Augmented Generation (RAG) system that allows users to ask natural-language questions about ETFs and equities. It retrieves semantically relevant documents stored in PostgreSQL (via the `pgvector` extension), builds an augmented prompt, and submits it to a locally-hosted Ollama LLM to generate a grounded answer.
+
+The system is intentionally narrow in scope: it answers questions using only pre-seeded document embeddings — it does not access live market data, portfolio data, or external APIs at query time.
+
+---
+
+## Entry Points
+
+### `POST /api/chat`
+Defined in `ChatController` (`src/EtfInsight.Api/Controllers/ChatController.cs`).
+
+Accepts a JSON body `{ "question": "..." }`. Validates the question is non-empty, then:
+1. Delegates to `IChatService.AskAiAsync` (which internally runs the full RAG pipeline).
+2. **Independently** re-generates the question embedding and re-runs the semantic search to attach `sources` to the response.
+
+Returns: `{ question, answer, sources: [{ ticker, similarity, excerpt }], timestamp }`.
+
+### `GET /api/chat/suggestions`
+Also in `ChatController`. Returns a hardcoded list of example questions (in Italian). No service or DB involvement.
+
+### `POST /api/search/seed`
+Defined in `SemanticSearchController` (`src/EtfInsight.Api/Controllers/SemanticSearchController.cs`).
+
+Developer-facing endpoint. Contains a hardcoded dictionary of 13 ticker → Italian description pairs (ETFs and equities). Generates embeddings for each and upserts them into `etf_documents`. No authentication guard.
+
+### `POST /api/search/query`
+Also in `SemanticSearchController`. Accepts `{ "query": "...", "limit": 5 }`. Generates an embedding for the query and returns raw similarity-ranked results from `etf_documents`. Bypasses the LLM entirely — this is a direct semantic search endpoint.
+
+---
+
+## Core Data Flow
+
+### Ask (`POST /api/chat`)
+
+```
+ChatController.Ask
+  └─ IChatService.AskAiAsync(question)                  [OllamaChatService]
+       ├─ IEmbeddingGenerator.GenerateEmbeddingAsync     [OllamaEmbeddingService]
+       │    └─ POST /api/embeddings → Ollama (nomic-embed-text)
+       │         returns float[]
+       ├─ ISemanticSearchRepository.SearchAsync(embedding, limit=5)  [DapperSemanticSearchRepository]
+       │    └─ pgvector cosine distance query on etf_documents
+       │         returns IEnumerable<SearchResult>
+       ├─ BuildAugmentedPrompt(question, docs)
+       │    └─ Constructs prompt string with AVAILABLE CONTEXT + INSTRUCTIONS + USER QUESTION
+       └─ GenerateResponseAsync(prompt)
+            └─ POST /api/generate → Ollama (llama3.2)
+                 Stream=false, Temperature=0.1
+                 returns string answer
+
+  [Back in ChatController]
+  └─ IEmbeddingGenerator.GenerateEmbeddingAsync(question)   ← DUPLICATE call
+  └─ ISemanticSearchRepository.SearchAsync(embedding, limit=5)  ← DUPLICATE call
+       → used only to populate `sources` field in the HTTP response
+```
+
+### Seed (`POST /api/search/seed`)
+
+```
+SemanticSearchController.SeedData
+  └─ for each (ticker, description) in hardcoded dict:
+       ├─ IEmbeddingGenerator.GenerateEmbeddingAsync(description)
+       └─ ISemanticSearchRepository.SaveEmbeddingAsync(ticker, description, embedding)
+            └─ INSERT ... ON CONFLICT (ticker) DO UPDATE on etf_documents
+```
+
+---
+
+## Key Components
+
+### `OllamaChatService` (`src/EtfInsight.Infrastructure/Services/OllamaChatService.cs`)
+- Implements `IChatService`.
+- Registered as `Scoped`.
+- Owns the full RAG pipeline: embed → retrieve → augment → generate.
+- Uses `IHttpClientFactory` with the named client `"Ollama"`. Sets `BaseAddress` from `AISettings.OllamaUrl` and `Timeout = 60s`.
+- Prompt is assembled in `BuildAugmentedPrompt`. Language is adaptive ("answer in the same language as the USER QUESTION").
+- `GenerateResponseAsync` POSTs to `/api/generate` with `Stream=false` and `Temperature=0.1`. Throws `InvalidOperationException` on empty response.
+- Error handling: wraps all exceptions in a new `InvalidOperationException` with a user-readable message. The original exception is preserved as inner exception.
+
+### `OllamaEmbeddingService` (`src/EtfInsight.Infrastructure/Services/OllamaEmbeddingService.cs`)
+- Implements `IEmbeddingGenerator`.
+- Registered as `Scoped`.
+- POSTs to `/api/embeddings` with `{ model, prompt }`. Returns `float[]`.
+- Timeout: 30s (shorter than the chat timeout).
+- Catches `HttpRequestException` separately for a clearer "Is Ollama running?" message.
+- `OllamaEmbeddingResponse` is a `public` nested class (inconsistent with `OllamaEmbeddingRequest` which is `internal`).
+
+### `DapperSemanticSearchRepository` (`src/EtfInsight.Infrastructure/Repositories/DapperSemanticSearchRepository.cs`)
+- Implements `ISemanticSearchRepository`.
+- Registered as `Scoped`. Takes `IDbConnection` (Npgsql, also scoped).
+- `SearchAsync`: uses cosine distance operator `<=>` on a `vector` column. Similarity is computed as `1 - distance`. Results are **not filtered** by a minimum similarity threshold — all rows are returned up to `limit`, regardless of relevance quality.
+- `SaveEmbeddingAsync`: upserts on `ticker`. Serialises the float array as a string literal `[f1,f2,...]` cast to `::vector`. Hardcodes `metadata` to `{"source": "manual_seed", "version": "1.0"}` and `is_mandatory = false` for all embeddings.
+- No `CancellationToken` support on either method (interface does not define it).
+
+### `ChatController` (`src/EtfInsight.Api/Controllers/ChatController.cs`)
+- No authentication or authorisation attributes. All endpoints are public.
+- Injects both `IChatService` and the lower-level `IEmbeddingGenerator`/`ISemanticSearchRepository` directly — this is unusual and creates a dual responsibility: the controller both delegates to the service and re-runs part of the service's work to populate `sources`.
+- `ChatRequest` is defined as a non-record `class` at the bottom of the file, with no validation attributes beyond the manual `IsNullOrWhiteSpace` check.
+
+### `SemanticSearchController` (`src/EtfInsight.Api/Controllers/SemanticSearchController.cs`)
+- No authentication. `/api/search/seed` is an unauthenticated write endpoint that modifies the vector store. Intended as a developer/admin tool but unguarded in production.
+- `SearchRequest.Limit` is `int?`; no upper-bound validation — a caller could request an arbitrarily large number of results.
+
+### `AISettings` (`src/EtfInsight.Core/Configuration/AISettings.cs`)
+- Bound from config section `"AI"` in `Program.cs`.
+- Defaults: `OllamaUrl = "http://localhost:11434"`, `EmbeddingModel = "nomic-embed-text"`, `ChatModel = "llama3.2"`, `EmbeddingDimensions = 768`.
+- `EmbeddingDimensions` is defined but **never consumed** anywhere in the codebase.
+
+### `IChatService` (`src/EtfInsight.Core/Services/IChatService.cs`)
+- Single method: `Task<string> AskAiAsync(string question)`. No `CancellationToken` parameter.
+
+### `ISemanticSearchRepository` (`src/EtfInsight.Core/Interfaces/ISemanticSearchRepository.cs`)
+- Two methods: `SaveEmbeddingAsync` and `SearchAsync`. Neither accepts a `CancellationToken`.
+
+---
+
+## External Dependencies
+
+### Ollama (HTTP)
+- Named `HttpClient` `"Ollama"` registered in `Program.cs` (no base address set at registration; set per-instance inside each service constructor).
+- Two endpoints used:
+  - `POST /api/embeddings` — embedding generation (model: `nomic-embed-text`, 768 dimensions)
+  - `POST /api/generate` — text generation (model: `llama3.2`, stream=false)
+- Assumed to be running locally or at the configured `OllamaUrl`. No health check, circuit breaker, or retry policy.
+
+### PostgreSQL + pgvector
+- `etf_documents` table with columns: `ticker` (unique), `content`, `embedding` (vector type), `metadata` (jsonb), `is_mandatory`, `created_at`.
+- Vector similarity search uses the `<=>` (cosine distance) operator provided by `pgvector`.
+- Dapper is used directly with raw SQL. No EF Core involvement for this feature.
+- `IDbConnection` is scoped (one `NpgsqlConnection` per HTTP request).
+
+---
+
+## Existing Patterns & Conventions
+
+- All AI-facing services live in `EtfInsight.Infrastructure.Services` and implement interfaces defined in `EtfInsight.Core`.
+- DI registration is manual in `Program.cs`; all AI services are `Scoped`.
+- Named `HttpClient` pattern is used consistently (`"Ollama"`, `"Airflow"`, `"OpenFigi"`).
+- Repository layer uses Dapper with raw SQL (no EF Core for read-heavy paths).
+- `AISettings` is the single configuration object for all AI-related settings, bound via `IOptions<AISettings>`.
+
+---
+
+## Potential Issues
+
+1. **Duplicate embedding + search in `ChatController.Ask`** (`ChatController.cs`, lines 55–56`): The controller independently regenerates the embedding and re-runs `SearchAsync` solely to populate the `sources` field. This doubles the cost of every chat request (two embedding calls to Ollama, two DB queries). The service already has the results internally but discards them.
+
+2. **No `CancellationToken` propagation**: `IChatService.AskAiAsync`, `IEmbeddingGenerator.GenerateEmbeddingAsync`, and `ISemanticSearchRepository` methods all omit `CancellationToken`. Long-running Ollama calls cannot be cancelled when the HTTP client disconnects.
+
+3. **No minimum similarity threshold in `SearchAsync`**: All documents up to `limit` are returned regardless of relevance. Very low-relevance documents will be injected into the LLM prompt, potentially degrading answer quality or causing hallucination.
+
+4. **Unauthenticated `/api/search/seed`**: This endpoint modifies the vector store. It is unprotected and callable by anyone in the current configuration.
+
+5. **`EmbeddingDimensions` setting is unused**: `AISettings.EmbeddingDimensions = 768` is never read. The actual dimension is determined by whatever the Ollama model returns. If the model changes, the schema may break silently.
+
+6. **`OllamaEmbeddingResponse` is `public`** (`OllamaEmbeddingService.cs`, line 84): A response DTO for an internal HTTP call is unnecessarily surfaced as a public type on the class.
+
+7. **No upper-bound validation on `SearchRequest.Limit`** (`SemanticSearchController.cs`, line 147): An unbounded value flows directly into the SQL `LIMIT` clause.
+
+8. **`HttpClient` base address set in constructor, not at registration**: Both `OllamaChatService` and `OllamaEmbeddingService` call `_httpClient.BaseAddress = new Uri(...)` after obtaining the client from the factory. Mutating a shared `HttpClient`'s `BaseAddress` post-construction is not safe if the named client is reused across scopes (though it works because new instances are created per named client).
+
+9. **System prompt is hardcoded as an inline string** (`OllamaChatService.cs`, lines 101–109): Prompt engineering is embedded in the service. Iterating on the prompt requires recompilation and redeployment.
+
+10. **`SearchResult` is a mutable class, not a record** (`SearchResult.cs`): Inconsistent with the project's preference for records for DTOs.
+
+---
+
+## Open Questions
+
+1. **Is multi-user / multi-tenant context intended for the chat feature?** Currently there is no portfolio or user context injected into the prompt — all users see the same document corpus.
+
+2. **What is the long-term document corpus strategy?** The only way to add documents today is via the `/api/search/seed` developer endpoint with a hardcoded dictionary. Is there a planned ingestion pipeline (e.g., from ETF metadata, fund factsheets)?
+
+3. **Should the chat feature support conversational history (multi-turn)?** The current implementation is fully stateless — each call is independent with no message history.
+
+4. **Is there a plan to replace Ollama with a hosted LLM API** (e.g., OpenAI, Azure OpenAI)? The current abstraction (`IChatService`, `IEmbeddingGenerator`) is thin enough to support a swap, but the prompt format and model-specific assumptions are baked in.
+
+5. **What is the intended embedding dimension?** `AISettings.EmbeddingDimensions = 768` matches `nomic-embed-text`, but this is never enforced at schema creation or at runtime. If a different model is configured, silent failures or type mismatches could occur in the vector column.
+

--- a/docs/ollama-seed/research.md
+++ b/docs/ollama-seed/research.md
@@ -1,0 +1,142 @@
+# Research: Ollama Seed (Semantic Search & RAG)
+
+## Overview
+
+The "ollama-seed" system is the local AI layer of the platform. It provides two capabilities:
+
+1. **Embedding generation & seeding** — converts ETF/equity descriptions into 768-dimensional vectors stored in PostgreSQL (pgvector), enabling semantic similarity search.
+2. **RAG-based chat** — answers user questions by embedding the query, retrieving the most relevant documents via cosine similarity, and feeding them as context to a local LLM (llama3.2) via Ollama.
+
+All AI operations run entirely on localhost through Ollama. No external API calls.
+
+## Entry Points
+
+| Route | Method | Controller | Purpose |
+|---|---|---|---|
+| `POST /api/search/seed` | POST | `SemanticSearchController` | Seeds the `etf_documents` table with hardcoded ETF/equity descriptions and their embeddings |
+| `POST /api/search/query` | POST | `SemanticSearchController` | Performs semantic similarity search against stored embeddings |
+| `POST /api/chat` | POST | `ChatController` | RAG pipeline: embed question → retrieve docs → augmented prompt → LLM answer |
+| `GET /api/chat/suggestions` | GET | `ChatController` | Returns a static list of suggested questions (Italian) |
+
+## Core Data Flow
+
+### Seed flow (`POST /api/search/seed`)
+
+1. Controller holds a hardcoded `Dictionary<string, string>` of 13 ticker→description pairs (8 ETFs + 5 equities). Descriptions are in Italian.
+2. For each entry, calls `IEmbeddingGenerator.GenerateEmbeddingAsync(description)`.
+3. `OllamaEmbeddingService` POSTs to `http://localhost:11434/api/embeddings` with model `nomic-embed-text` and the description as prompt.
+4. Ollama returns a `float[]` embedding (768 dimensions).
+5. `DapperSemanticSearchRepository.SaveEmbeddingAsync` serialises the float array to a string `[0.1,0.2,...]` and executes an `INSERT ... ON CONFLICT (ticker) DO UPDATE` into `etf_documents`.
+6. Metadata is hardcoded: `{"source": "manual_seed", "version": "1.0"}`, `is_mandatory = false`.
+
+### Query flow (`POST /api/search/query`)
+
+1. Validates `request.Query` is non-empty.
+2. Embeds the query text via `OllamaEmbeddingService`.
+3. `DapperSemanticSearchRepository.SearchAsync` runs a pgvector cosine distance query: `1 - (embedding <=> @QueryEmbedding::vector)` ordered ascending by distance, limited to `request.Limit ?? 5`.
+4. Returns ticker, content, and similarity score.
+
+### Chat flow (`POST /api/chat`)
+
+1. Validates `request.Question`.
+2. Delegates to `OllamaChatService.AskAiAsync(question)`:
+   - Embeds the question.
+   - Retrieves top-5 documents via semantic search.
+   - Builds an augmented prompt with context and instructions (system prompt is inline, not configurable).
+   - POSTs to `http://localhost:11434/api/generate` with model `llama3.2`, `stream: false`, `temperature: 0.1`.
+3. **Back in the controller**, generates the embedding a second time and searches again to return sources alongside the answer. This duplicates the work already done inside `OllamaChatService`.
+
+## Key Components
+
+### `AISettings` — `EtfInsight.Core/Configuration/AISettings.cs`
+- POCO bound from `appsettings.json` section `AI`.
+- Fields: `OllamaUrl`, `EmbeddingModel` (`nomic-embed-text`), `ChatModel` (`llama3.2`), `EmbeddingDimensions` (768).
+- `EmbeddingDimensions` is never used at runtime — it exists as documentation only.
+
+### `IEmbeddingGenerator` / `OllamaEmbeddingService` — `Infrastructure/Services/OllamaEmbeddingService.cs`
+- Single method: `GenerateEmbeddingAsync(string input) → float[]`.
+- Creates a new `HttpClient` from `IHttpClientFactory` in the constructor, sets `BaseAddress` and `Timeout` (30s) on every instantiation.
+- Uses Ollama's legacy `/api/embeddings` endpoint (singular prompt field).
+- No `CancellationToken` support.
+- Response DTO `OllamaEmbeddingResponse` is a nested public class; request DTO `OllamaEmbeddingRequest` is internal at namespace level — inconsistent.
+
+### `ISemanticSearchRepository` / `DapperSemanticSearchRepository` — `Infrastructure/Repositories/DapperSemanticSearchRepository.cs`
+- `SaveEmbeddingAsync(ticker, content, embedding)` — upserts by ticker. Embedding serialised manually with `InvariantCulture`.
+- `SearchAsync(queryEmbedding, limit)` — cosine distance search. No filtering, no pagination, no `CancellationToken`.
+- Uses raw `IDbConnection` (Dapper), not EF Core.
+
+### `IChatService` / `OllamaChatService` — `Infrastructure/Services/OllamaChatService.cs`
+- `AskAiAsync(string question) → string`.
+- Performs the full RAG pipeline internally: embed → search → augment → generate.
+- Builds prompt inline with string concatenation (no newlines between sections — `INSTRUCTIONS:` runs into the context block).
+- `temperature: 0.1` hardcoded.
+- No `CancellationToken` support.
+- `OllamaGenerateRequest` and `OllamaChatResponse` are internal classes at namespace level.
+
+### `SemanticSearchController` — `Api/Controllers/SemanticSearchController.cs`
+- `SeedData()` — no auth, no idempotency key, no input parameters. Hardcoded seed data lives in the controller.
+- `Query()` — accepts `SearchRequest` (nested public class) with `Query` and optional `Limit`.
+- No `CancellationToken` in any action method.
+
+### `ChatController` — `Api/Controllers/ChatController.cs`
+- `Ask()` — injects `IEmbeddingGenerator` and `ISemanticSearchRepository` directly despite also injecting `IChatService` which already uses them internally. This causes the embedding to be generated twice per request.
+- `GetSuggestions()` — returns hardcoded Italian question strings.
+- No `CancellationToken` in any action method.
+
+### Schema — `src/db/04_etf_documents_schema.sql`
+- Table `etf_documents`: UUID PK, `ticker VARCHAR(20) NOT NULL UNIQUE`, `content TEXT`, `metadata JSONB`, `embedding vector(768)`, `created_at`, `is_mandatory`.
+- FK to `etf_metadata(ticker)` with `ON DELETE CASCADE`.
+- HNSW index on embedding using `vector_cosine_ops`.
+- The `UNIQUE` constraint on `ticker` means only one document per ticker — no multi-document knowledge base.
+
+## External Dependencies
+
+| Dependency | Usage |
+|---|---|
+| **Ollama** (localhost:11434) | Embedding generation (`/api/embeddings`) and text generation (`/api/generate`) |
+| **nomic-embed-text** model | 768-dim embedding model |
+| **llama3.2** model | Chat/generation model |
+| **PostgreSQL + pgvector** | Vector storage and cosine similarity search |
+| **Dapper** | Raw SQL query execution for vector operations |
+
+## Existing Patterns & Conventions
+
+- Interfaces in `EtfInsight.Core.Interfaces`, implementations in `EtfInsight.Infrastructure`.
+- DI registration in `Program.cs` with `AddScoped`.
+- `IDbConnection` injected as scoped `NpgsqlConnection`.
+- Repositories use Dapper with raw SQL, not EF Core (EF Core is used elsewhere in the project).
+- No result types — exceptions used for all error paths.
+- No `CancellationToken` anywhere in the AI/search stack.
+
+## Potential Issues
+
+1. **Double embedding in `ChatController.Ask()`** (ChatController.cs:55) — The controller generates the question embedding and searches again after `AskAiAsync` already did the same work internally. Two Ollama round-trips and two DB queries per chat request.
+
+2. **No `CancellationToken` propagation** — None of the interfaces (`IEmbeddingGenerator`, `ISemanticSearchRepository`, `IChatService`) accept `CancellationToken`. All Ollama HTTP calls and DB queries run without cancellation support.
+
+3. **Seed data hardcoded in controller** (SemanticSearchController.cs:34-63) — 13 descriptions baked into the controller body. Not extensible, not configurable, mixes data with request handling.
+
+4. **Seed endpoint has no auth or protection** — `POST /api/search/seed` is publicly accessible with no authorization. It overwrites all existing embeddings.
+
+5. **Single document per ticker** — The `UNIQUE` constraint on `ticker` means the knowledge base is limited to one description per instrument. Cannot store multiple documents (factsheets, news, analysis) per ticker.
+
+6. **`OllamaEmbeddingService` sets `BaseAddress` in constructor on a factory-created client** (OllamaEmbeddingService.cs:31-32) — The `IHttpClientFactory` client named "Ollama" has its base address overwritten every time the service is constructed. This is safe only because it's scoped, but it defeats the purpose of named client configuration.
+
+7. **`EmbeddingDimensions` never validated** (AISettings.cs:13) — If a model returning a different dimension count is configured, the `vector(768)` column will reject the insert at DB level with no helpful error message.
+
+8. **Prompt formatting** (OllamaChatService.cs:101-109) — String concatenation with `$"..."` produces no newlines between sections. The `INSTRUCTIONS:` block runs directly into the context, likely degrading LLM output quality.
+
+9. **Broad `catch (Exception)` in controllers** — Both controllers catch `Exception` and return 500, violating the coding standard of catching specific exceptions.
+
+10. **Response DTOs are anonymous types** — Both controllers return `Ok(new { ... })` anonymous objects. No typed response contracts.
+
+11. **`SearchResult` is a mutable class, not a record** (SearchResult.cs) — Properties have no `required` modifier and are not init-only. Violates the coding standard preference for records for DTOs.
+
+## Open Questions
+
+1. Should the seed endpoint be replaced by an automated ingestion pipeline (e.g., from the Airflow `etf_knowledge_builder` DAG)?
+2. Is the one-document-per-ticker constraint intentional, or should the schema support multiple documents per ticker for a richer knowledge base?
+3. Should the chat service return source documents as part of its response to avoid the double-embedding problem in the controller?
+4. Is Italian the intended language for all seed descriptions and suggestions, or should multi-language support be considered?
+5. Is there a plan to migrate from the legacy Ollama `/api/embeddings` endpoint to the newer `/api/embed` endpoint?
+

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,7 +25,7 @@ x-airflow-common: &airflow-common
     BACKFILL_TO: ${BACKFILL_TO:-2026-02-28}
     AIRFLOW__CORE__TEST_CONNECTION: "Enabled"
     AIRFLOW__API__AUTH_BACKENDS: "airflow.api.auth.backend.basic_auth"
-    _PIP_ADDITIONAL_REQUIREMENTS: "yfinance==1.2.0 pandas==2.2.2 pytest==8.2.0"
+    _PIP_ADDITIONAL_REQUIREMENTS: "yfinance==1.2.0 pandas==2.2.2 pytest==8.2.0 duckduckgo-search==7.5.1 beautifulsoup4==4.12.3"
   volumes:
     - ../airflow/dags:/opt/airflow/dags
     - ../airflow/plugins:/opt/airflow/plugins

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -32,6 +32,7 @@ x-airflow-common: &airflow-common
     - ../airflow/include:/opt/airflow/include
     - airflow_logs:/opt/airflow/logs
     - ../airflow/tests:/opt/airflow/tests
+    - /airflow/data/factsheets
   depends_on:
     postgres-airflow:
       condition: service_healthy

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -32,7 +32,7 @@ x-airflow-common: &airflow-common
     - ../airflow/include:/opt/airflow/include
     - airflow_logs:/opt/airflow/logs
     - ../airflow/tests:/opt/airflow/tests
-    - /airflow/data/factsheets
+    - ../data/raw/factsheets:/opt/airflow/data/factsheets
   depends_on:
     postgres-airflow:
       condition: service_healthy

--- a/src/db/10_etf_factsheet_status_schema.sql
+++ b/src/db/10_etf_factsheet_status_schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS etf_factsheet_status (
+    isin        VARCHAR(12) NOT NULL PRIMARY KEY,
+    ticker      VARCHAR(20) NOT NULL REFERENCES etf_metadata(ticker) ON DELETE CASCADE,
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending',
+    source      VARCHAR(30),
+    pdf_url     TEXT,
+    local_path  TEXT,
+    error       TEXT,
+    attempts    INT NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS etf_factsheet_status_status ON etf_factsheet_status (status);


### PR DESCRIPTION
This pull request introduces a new Airflow DAG and supporting infrastructure for automated ETF factsheet retrieval, including robust PDF fetching logic, database integration, and comprehensive tests. The DAG attempts to retrieve factsheet PDFs for ETFs using DuckDuckGo search and a JustETF fallback, updates their status in the database, and includes error handling and retry logic. The changes also add new dependencies and expand test coverage.

**New ETF factsheet retrieval pipeline:**

* Added a new DAG (`etf_knowledge_builder.py`) that orchestrates fetching pending ETF ISINs, retrieving their factsheets (via DuckDuckGo and JustETF), and updating their status in the database. The DAG is scheduled weekly and ensures only one active run at a time.
* Implemented the `factsheet_retrieval.py` module, which encapsulates logic for searching and downloading factsheet PDFs, handling network errors, validating PDF content, and introducing randomized sleep intervals to avoid rate limits.

**Database integration:**

* Extended `ETFDatabaseHook` with methods to fetch ISINs needing factsheet retrieval and to upsert factsheet retrieval status, including retries for failed attempts (up to 3).

**Testing and validation:**

* Added comprehensive unit tests for the factsheet retrieval logic, covering DuckDuckGo and JustETF scraping, PDF download validation, and fallback/error scenarios.
* Updated DAG integrity tests to include the new DAG and verify its schedule, task IDs, and configuration. [[1]](diffhunk://#diff-1ef516de4d58cfffe2a80c4548015eeef2b23aeea896fbe441811ec6d937656aL13-R13) [[2]](diffhunk://#diff-1ef516de4d58cfffe2a80c4548015eeef2b23aeea896fbe441811ec6d937656aR98-R111)

**Dependencies:**

* Added `duckduckgo-search` and `beautifulsoup4` to requirements for web search and HTML parsing.